### PR TITLE
Fixed composer.json format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,8 @@
     "minimum-stability": "beta",
     "prefer-stable": true,
     "autoload": {
-        "Http\\Demo\\": "src/"
+        "psr-4": {
+            "Http\\Demo\\": "src/"
+        }
     }
 }


### PR DESCRIPTION
The format for `composer.json` was wrong.

Here what was happening.

```
me@foo$ composer validate
./composer.json is invalid, the following errors/warnings were found:
autoload : invalid value (Http\Demo\), must be one of psr-0, psr-4, classmap, files, exclude-from-classmap
```
